### PR TITLE
[ 027 ] Shell modes: early implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SRCS	= \
 	./shell-kvll.c \
 	./shell-alias.c \
 	./shell-statusline.c \
+	./shell-getopt.c \
 	./shell.c
 OBJS	= $(SRCS:.c=.o)
 NAME	= shell

--- a/shell-builtin.c
+++ b/shell-builtin.c
@@ -35,6 +35,7 @@ int	sh_bltin_exit(t_sh *sh, char **cmd) {
 	}
 
 	sh_quit(sh);
+	printf("exit\n");
 	exit(_exit);
 }
 

--- a/shell-builtin.c
+++ b/shell-builtin.c
@@ -74,8 +74,6 @@ int	sh_bltin_cd(char **cmd) {
 }
 
 int	sh_bltin_export(char **cmd) {
-	char	*_key;
-	char	*_value;
 	char	*_start;
 	char	*_end;
 
@@ -86,40 +84,22 @@ int	sh_bltin_export(char **cmd) {
 		}
 		return (1);
 	}
-	if (!*(cmd + 1) || strcmp(*(cmd + 1), "|")) {
-		_key = _value = 0;
-		_start = _end = *cmd;
-		while (*_end && *_end != '=')
+	if (!*(cmd + 1) || !sh_iskeyword(*(cmd + 1))) {
+		_end = _start = *cmd;
+		while (*_end && *_end != '=') {
 			_end++;
-		_key = (char *) calloc(_end - _start, sizeof(char));
-		if (!_key) {
-			perror("calloc");
+		}
+		if (!*_end) {
 			return (0);
 		}
-		_key = strncpy(_key, _start, _end - _start);
-		if (!*_end) {
-			if (!sh_export(_key, "")) {
-				perror("setenv");
-				return (0);
-			}
-		}
 		else {
-			_start = ++_end;
-			while (*_end)
-				_end++;
-			_value = (char *) calloc(_end - _start + 1, sizeof(char));
-			if (!_value) {
-				perror("calloc");
-				free(_key);
+			*_end = 0;
+			if (!sh_export(_start, (_end + 1))) {
 				return (0);
 			}
-			_value = strncpy(_value, _start, _end - _start);
-			if (!sh_export(_key, _value)) {
-				perror("setenv");
-				return (0);
-			}
+			*_end = '=';
+			return (1);
 		}
-		return (1);
 	}
 	return (0);
 }

--- a/shell-getopt.c
+++ b/shell-getopt.c
@@ -1,0 +1,37 @@
+#include "shell.h"
+
+static int	__sh_helpmsg(void);
+
+static struct option ___shell_longopt[] = {
+    { "command",	required_argument,	NULL,	'c' },
+    { "version",	no_argument,		NULL,	'v' },
+    { "help",		no_argument,		NULL,	'h' },
+    { 0,			0,					0,		0	}
+};
+
+int	sh_getopt(t_sh *sh, int ac, char **av) {
+	char	_c;
+
+	while ((_c = getopt_long(ac, av, "c:vh", ___shell_longopt, NULL)) != -1) {
+		switch (_c) {
+			case ('v') : { printf("%s\n", _shell_version_); exit(0); } break;
+			case ('h') : { __sh_helpmsg(); exit(0); } break;
+			case ('c') : {
+				sh->settings[_shell_setting_mode_] = 0;
+				sh->settings[_shell_setting_read_dotfiles_] = 0;
+				sh->settings[_shell_setting_silent_] = 1;
+				sh->input = strdup(optarg);
+				sh_input(sh);
+				sh_quit(sh);
+				exit (0);
+			} break;
+			default: { exit(0); } break;
+		}
+	}
+	return (1);
+}
+
+static int	__sh_helpmsg(void) {
+	printf("Shell help message *to be added*\n");
+	return (1);
+}

--- a/shell-getopt.c
+++ b/shell-getopt.c
@@ -21,7 +21,7 @@ int	sh_getopt(t_sh *sh, int ac, char **av) {
 				sh->settings[_shell_setting_read_dotfiles_] = 0;
 				sh->settings[_shell_setting_silent_] = 1;
 				sh->input = strdup(optarg);
-				sh_input(sh);
+				sh_handle_input(sh);
 				sh_quit(sh);
 				exit (0);
 			} break;

--- a/shell-rc.c
+++ b/shell-rc.c
@@ -9,14 +9,18 @@
  * */
 
 int		sh_rc(t_sh *sh, t_path fp) {
-	t_sh	_sh;
+	bool	_read_dotfiles;
 
-	sh_init_struct(&_sh);
+	_read_dotfiles = sh->settings[_shell_setting_read_dotfiles_];
+	if (!_read_dotfiles) {
+		return (1);
+	}
+
 	/* ...Opening dotfile... */
-	_sh.fd_curin = open(fp, O_RDONLY);
-	if (_sh.fd_curin == -1) {
-		_sh.fd_curin = open(fp, O_RDWR | O_CREAT, 0664);
-		if (_sh.fd_curin == -1) {
+	sh->fd_curin = open(fp, O_RDONLY);
+	if (sh->fd_curin == -1) {
+		sh->fd_curin = open(fp, O_RDWR | O_CREAT, 0664);
+		if (sh->fd_curin == -1) {
 			perror("open");
 			return (0);
 		}
@@ -24,15 +28,11 @@ int		sh_rc(t_sh *sh, t_path fp) {
 	}
 	
 	/* ...Processing dotfile... */
-	sh_loop(&_sh, true);
+	sh->settings[_shell_setting_silent_] = true;
+	sh_loop(sh);
+	sh->settings[_shell_setting_silent_] = false;
 	
 	/* ...finish */
-	sh->aliases = _sh.aliases;
-	if (_sh.statusline) {
-		sh->statusline = strdup(_sh.statusline);
-		free(_sh.statusline);
-	}
-	sh_free(&_sh);
-	sh_close_fds(&_sh);
+	close(sh->fd_curin); sh->fd_curin = -1;
 	return (1);
 }

--- a/shell-utils.c
+++ b/shell-utils.c
@@ -1,7 +1,7 @@
 #include "shell.h"
 #include <sys/param.h>
 
-void	sh_free(struct s_shell *sh) {
+void	sh_free_input(struct s_shell *sh) {
 	if (sh->input) {
 		free(sh->input); sh->input = 0;
 	}
@@ -22,12 +22,12 @@ void	sh_free2d(void **ptr) {
 }
 
 void	sh_close_fds(t_sh *sh) {
-	close(sh->fd_pipe[0]);
-	close(sh->fd_pipe[1]);
-	close(sh->fd_null);
-	close(sh->fd_curin);
-	dup2(sh->fd_stdin, 0); close(sh->fd_stdin);
-	dup2(sh->fd_stdout, 1); close(sh->fd_stdout);
+	close(sh->fd_pipe[0]); sh->fd_pipe[0] = -1;
+	close(sh->fd_pipe[1]); sh->fd_pipe[1] = -1;
+	close(sh->fd_null); sh->fd_null = -1;
+	close(sh->fd_curin); sh->fd_curin = -1;
+	dup2(sh->fd_stdin, 0); close(sh->fd_stdin); sh->fd_stdin = -1;
+	dup2(sh->fd_stdout, 1); close(sh->fd_stdout); sh->fd_stdout = -1;
 }
 
 bool	sh_iskeyword(const char *cmd) {

--- a/shell-var.c
+++ b/shell-var.c
@@ -18,11 +18,13 @@ char	**sh_expand(t_sh *sh, char **cmd) {
 int	sh_export(const char *key, const char *value) {
 	if (getenv(key)) {
 		if (setenv(key, value, 1) == -1) {
+			perror("setenv");
 			return (0);
 		}
 	}
 	else {
 		if (setenv(key, value, 0) == -1) {
+			perror("setenv");
 			return (0);
 		}
 	}

--- a/shell.c
+++ b/shell.c
@@ -3,13 +3,13 @@
 static void	__sh_enable_ctrlc(int);
 static void	__sh_disable_ctrlc(int);
 
-int main(void) {
+int main(int ac, char **av) {
 	t_sh	_sh;
 
-	if (!sh_init(&_sh)) {
+	if (!sh_init(&_sh, ac, av)) {
 		return (1);
 	}
-	if (!sh_loop(&_sh, false)) {
+	if (!sh_loop(&_sh)) {
 		return (1);
 	}
 	if (!sh_quit(&_sh)) {
@@ -18,34 +18,34 @@ int main(void) {
 	exit(0);
 }
 
-int	sh_init(t_sh *sh) {
+int	sh_init(t_sh *sh, int ac, char **av) {
 	t_path	_path_home;
 
-	if (!sh) {
-		return (0);
-	}
-	/* Shell object setup */
-	if (!sh_init_struct(sh)) {
-		return (0);
-	}
+	memset(sh, 0, sizeof(struct s_shell));
+	sh_init_defopt(sh);
+	sh_getopt(sh, ac, av);
+	sh_init_struct(sh);
+	sh_init_env();
 
-	/* Environment setup */
-	if (!sh_init_env()) {
-		return (0);
-	}
-
-	/* Reading rcfile */
+	/* $HOME dotfiles */
 	memset(_path_home, 0, PATH_MAX);
 	strcat(_path_home, getenv("HOME"));
 	strcat(_path_home, "/.shrc");
-	if (!sh_rc(sh, _path_home)) {
-		return (0);
-	}
+	sh_rc(sh, _path_home);
+	return (1);
+}
+
+int	sh_init_defopt(t_sh *sh) {
+	/* Default: run interactive mode */
+	sh->settings[_shell_setting_mode_] = 1;
+	/* Default: read dotfiles */
+	sh->settings[_shell_setting_read_dotfiles_] = 1;
+	/* Default: print prompts to the stdout */
+	sh->settings[_shell_setting_silent_] = 0;
 	return (1);
 }
 
 int	sh_init_struct(t_sh *sh) {
-	memset(sh, 0, sizeof(struct s_shell));
 	sh->fd_stdin = dup(0);
 	if (sh->fd_stdin == -1) {
 		perror("dup2");
@@ -89,10 +89,15 @@ int	sh_init_env(void) {
 	return (1);
 }
 
-int	sh_loop(t_sh *sh, bool silent) {
-	while (1) {
+int	sh_loop(t_sh *sh) {
+	bool	_silent;
+	int		_mode;
+
+	_mode = sh->settings[_shell_setting_mode_];
+	_silent = sh->settings[_shell_setting_silent_];
+	do {
 		signal(SIGINT, __sh_enable_ctrlc);
-		if (silent) {
+		if (_silent) {
 			dup2(sh->fd_null, 1);
 			sh->input = sh_getline(sh->fd_curin);
 			dup2(sh->fd_stdout, 1);
@@ -102,23 +107,33 @@ int	sh_loop(t_sh *sh, bool silent) {
 		}
 		signal(SIGINT, __sh_disable_ctrlc);
 		if (sh->input) {
-			if (strcmp(sh->input, "")) {
-				if (!silent) {
-					add_history(sh->input);
-				}
-				sh->tokens = sh_parse(sh->input, sh);
-				if (sh->tokens && *sh->tokens[0] != '#') {
-					sh_execute(sh);
-				}
-			}
-			sh_free(sh);
-		}
-		else {
-			if (silent) {
+			if (!sh_input(sh)) {
 				break;
 			}
 		}
+		else {
+			if (_silent) {
+				break;
+			}
+		}
+	} while (_mode);
+	return (1);
+}
+
+int	sh_input(t_sh *sh) {
+	bool	_silent;
+
+	_silent = sh->settings[_shell_setting_silent_];
+	if (strcmp(sh->input, "")) {
+		if (!_silent) {
+			add_history(sh->input);
+		}
+		sh->tokens = sh_parse(sh->input, sh);
+		if (sh->tokens && *sh->tokens[0] != '#') {
+			sh_execute(sh);
+		}
 	}
+	sh_free_input(sh);
 	return (1);
 }
 
@@ -126,10 +141,12 @@ int	sh_quit(t_sh *sh) {
 	if (!sh) {
 		return (0);
 	}
-	sh_free(sh);
+	sh_free_input(sh);
 	sh_close_fds(sh);
 	sh_alias_clear(sh);
-	free(sh->statusline);
+	if (sh->statusline) {
+		free(sh->statusline); sh->statusline = 0;
+	}
 	return (1);
 }
 

--- a/shell.c
+++ b/shell.c
@@ -107,7 +107,7 @@ int	sh_loop(t_sh *sh) {
 		}
 		signal(SIGINT, __sh_disable_ctrlc);
 		if (sh->input) {
-			if (!sh_input(sh)) {
+			if (!sh_handle_input(sh)) {
 				break;
 			}
 		}
@@ -120,7 +120,7 @@ int	sh_loop(t_sh *sh) {
 	return (1);
 }
 
-int	sh_input(t_sh *sh) {
+int	sh_handle_input(t_sh *sh) {
 	bool	_silent;
 
 	_silent = sh->settings[_shell_setting_silent_];

--- a/shell.h
+++ b/shell.h
@@ -76,7 +76,7 @@ int		sh_init_defopt(t_sh *);
 int		sh_init_struct(t_sh *);
 int		sh_init_env(void);
 int		sh_loop(t_sh *);
-int		sh_input(t_sh *);
+int		sh_handle_input(t_sh *);
 int		sh_quit(t_sh *);
 int		sh_input(t_sh *);
 

--- a/shell.h
+++ b/shell.h
@@ -12,11 +12,23 @@
 # include <stdlib.h>
 # include <string.h>
 # include <unistd.h>
+# include <getopt.h>
 # include <sys/wait.h>
 # include <sys/param.h>
 # include <sys/utsname.h>
 # include <readline/readline.h>
 # include <readline/history.h>
+# if !defined (_shell_version_major_)
+#  define _shell_version_major_ 1
+# endif
+# if !defined (_shell_version_minor_)
+#  define _shell_version_minor_ 0
+# endif
+# define _shell_version_ "1.0"
+# define _shell_setting_mode_ 0
+# define _shell_setting_read_dotfiles_ 1
+# define _shell_setting_silent_ 2
+# define _shell_setting_count_ 3
 
 struct s_kvll {
 	void			*key;
@@ -28,17 +40,28 @@ typedef struct s_kvll	t_kvll;
 
 struct s_shell {
 	t_kvll	*aliases;
-	char	**tokens;
-	char	*input;
-	char	*statusline;
-	char	*distro;
+	/* settings */
+	struct {
+		int		settings[128];
+	};
+	/* textual information */
+	struct {
+		char	**tokens;
+		char	*input;
+		char	*statusline;
+		char	*distro;
+	};
+	/* file descriptors */
+	struct {
+		int		fd_pipe[2];
+		int		fd_curin;
+		int		fd_stdin;
+		int		fd_stdout;
+		int		fd_null;
+	};
+	/* other */
 	int		exit_stat;
-	int		fd_curin;
-	int		fd_stdin;
-	int		fd_stdout;
-	int		fd_null;
 	int		pid;
-	int		fd_pipe[2];
 };
 
 typedef struct s_shell	t_sh;
@@ -48,12 +71,17 @@ typedef char	t_path[PATH_MAX];
 extern char	**environ;
 
 /* shell.c */
-int		sh_init(t_sh *);
+int		sh_init(t_sh *, int, char **);
+int		sh_init_defopt(t_sh *);
 int		sh_init_struct(t_sh *);
 int		sh_init_env(void);
-int		sh_loop(t_sh *, bool);
+int		sh_loop(t_sh *);
+int		sh_input(t_sh *);
 int		sh_quit(t_sh *);
 int		sh_input(t_sh *);
+
+/* shell-getopt.c */
+int		sh_getopt(t_sh *, int, char **);
 
 /* shell-exec.c */
 int		sh_execute(t_sh *);
@@ -64,7 +92,7 @@ char	**sh_lnsplt(const char *, size_t *);
 bool	sh_parse_err(char **);
 
 /* shell-utils.c */
-void	sh_free(t_sh *);
+void	sh_free_input(t_sh *);
 void	sh_free2d(void **);
 void	sh_close_fds(t_sh *);
 bool	sh_iskeyword(const char *);

--- a/todo.txt
+++ b/todo.txt
@@ -16,6 +16,8 @@ Done:
 
 ToDo:
 
+- [ ] Argument parsing;
+- [ ] Interactive and non-interactive shell;
 - [ ] Advanced completion engine;
 
 Optional:


### PR DESCRIPTION
I've started implementing a basic option parsing and shell modes. Now, using the "-c" flag you can use shell in non - interactive mode which was a possible cause of many breaks of tools such as gdb (still working on this problem tho). The current primitive implementation allows me to expand the shell settings system to handle more cases, mixing all the different stuff and so forth